### PR TITLE
Shorten install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### 🍎 MacOS
 
-Simply run `brew tap Matt-Gleich/homebrew-taps` and then `brew install nuke`
+Simply run `brew install Matt-Gleich/taps/nuke`
 
 ### 🐧 Linux
 


### PR DESCRIPTION
## Description

`brew tap xyz/xyz`
and 
`brew install xyz`
can be shortened to
`brew install xyz/xyz/xyz`.

Also, `homebrew-` doesn't need to be included in the tap name

## Steps

- [ ] My change requires a change to the documentation
- [ ] I have updated the accessible documentation according
- [x] I have read the **CONTRIBUTING.md** file
- [x] There is no duplicate open or closed pull request for this fix/addition/issue resolution.

## Original Issue

N/A