### PR TITLE
add the possibility to skip selecting 'running from app' (close #36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ By default nuke checks if there is an update every time you run it. If you want 
 ignoredUpdates: true
 ```
 
+### 🚫 Ignoring running nuke from app
+
+By default nuke ask you to select the application from which you are running it. Once selected, it will be ignored. If you want to turn it off, let's say for automation, add the following to your config:
+
+```yaml
+ignoredRunningFrom: true
+```
+
+If you set `ignoredRunningFrom` to `true`, be sure to add the application you are using to run nuke from into [ignoreApps](#-ignoring-apps). You can also pass it as an argument. If you don't, nuke will raise an error trying to close the application you are running it from.
+
 ## 🙋‍♀️🙋‍♂️ Contributing
 
 All contributions are welcome! Just make sure that its not an already existing issue or pull request.

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 	s.Stop()
 
 	// Getting executing terminal
-	cleanedApps := input.ExecutingTerm(apps, ignoredApps)
+	cleanedApps := input.ExecutingTerm(apps, ignoredApps, configContents.IgnoredRunningFrom)
 	fmt.Println("")
 
 	// Quitting applications

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,8 +11,9 @@ var path = "/.config/nuke/"
 
 // Config for nuke
 type Conf struct {
-	IgnoreUpdates bool     `yaml:"ignoredUpdates"`
-	IgnoredApps   []string `yaml:"ignoredApps"`
+	IgnoreUpdates      bool     `yaml:"ignoredUpdates"`
+	IgnoredApps        []string `yaml:"ignoredApps"`
+	IgnoredRunningFrom bool     `yaml:"ignoredRunningFrom"`
 }
 
 // Check if the config exists


### PR DESCRIPTION
## Description

Add the possibility to skip selecting 'running from app'. Useful for automation, and when the application is already in the ignore list.

## Steps

- [X] My change requires a change to the documentation
- [X] I have updated the accessible documentation according
- [X] I have read the **CONTRIBUTING.md** file
- [X] There is no duplicate open or closed pull request for this fix/addition/issue resolution.

## Original Issue

This PR resolves #36

